### PR TITLE
Pass the package name in the resource name instead of the argument

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,19 +50,16 @@ class git(
     }
   }
 
-  package{'git':
+  package{ $package:
     ensure => $ensure,
-    name   => $package,
   }
 
-  package{'git-svn':
+  package{ $git::params::svn_package:
     ensure => $ensure_svn,
-    name   => $git::params::svn_package,
   }
 
-  package{'git-gui':
+  package{ $git::params::gui_package:
     ensure => $ensure_gui,
-    name   => $git::params::gui_package,
   }
 
   # Need to consider if this should happen or not.

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -90,7 +90,7 @@ describe 'git', :type => :class do
     end
     describe "with no parameters" do
       it { should contain_class('git::params') }
-      it { should contain_package('git').with(
+      it { should contain_package('git-core').with(
         'ensure'  => 'installed',
         'name'    => 'git-core'
       ) }
@@ -137,7 +137,11 @@ describe 'git', :type => :class do
       it { should contain_class('git::params') }
       it { should contain_package('git').with(
         'ensure' => 'installed',
-        'name'   => ['git', 'git-core']
+        'name'   => 'git'
+      ) }
+      it { should contain_package('git-core').with(
+        'ensure' => 'installed',
+        'name'   => 'git-core'
       ) }
     end
   end


### PR DESCRIPTION
The reason is that the name argument can not be an array
