### PR TITLE
Add support Puppet 4.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@ class git::params {
   $su_cmd       = '/bin/su'
 
   case $::osfamily {
-    Debian: {
+    'Debian': {
       if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '11') < 0 {
         $package = 'git-core'
       }else{
@@ -19,15 +19,15 @@ class git::params {
       }
       $grep_cmd =  '/bin/grep'
     }
-    RedHat: {
+    'RedHat': {
       $package = 'git'
       $grep_cmd = '/bin/grep'
     }
-    ArchLinux:{
+    'ArchLinux':{
       $package = 'git'
       $grep_cmd = '/usr/bin/grep'
     }
-    Suse: {
+    'Suse': {
       $package  = ['git', 'git-core']
       $grep_cmd = '/usr/bin/grep'
     }


### PR DESCRIPTION
#### Testing:

before fix:

```
# puppet -V
4.5.3
# puppet agent -t --environment=support --summarize                   
Info: Using configured environment 'support'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Package[git] is already declared in file /etc/puppetlabs/code/environments/support/modules/colorprompt/manifests/init.pp:240; cannot redeclare at /etc/puppetlabs/code/environments/support/modules/git/manifests/init.pp:53 at /etc/puppetlabs/code/environments/support/modules/git/manifests/init.pp:53:3 on node .........
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
Time:
         Last run: 1469114128
Version:
           Config: 
           Puppet: 4.5.3
```

after fix:

```
puppet agent -t --environment=support
Info: Using configured environment 'support'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for ..............
Info: Applying configuration version '1469114324'
Notice: /Stage[main]/Roles::Common/Git::Config[core_editor_mkonyahin]/Exec[git_config_core_editor_mkonyahin]/returns: executed successfully
Notice: /Stage[main]/Roles::Common/Git::Config[merge_tool_mkonyahin]/Exec[git_config_merge_tool_mkonyahin]/returns: executed successfully
Notice: /Stage[main]/Roles::Common/Git::Config[branch_autosetuprebase_mkonyahin]/Exec[git_config_branch_autosetuprebase_mkonyahin]/returns: executed successfully
Notice: /Stage[main]/Roles::Common/Git::User[mkonyahin]/Git::Config[mkonyahin_name]/Exec[git_config_mkonyahin_name]/returns: executed successfully
Notice: /Stage[main]/Roles::Common/Git::User[mkonyahin]/Git::Config[mkonyahin_email]/Exec[git_config_mkonyahin_email]/returns: executed successfully
Notice: Applied catalog in 14.55 seconds
```
